### PR TITLE
Fix external refresh token error

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -215,12 +215,6 @@ export const auth = ({
   const logout: AuthSDK["logout"] = async opts => {
     const authPluginId = storage.getAuthPluginId();
 
-    if (authPluginId && !opts?.input) {
-      throw Error(
-        "input should be provided when logged in with external plugin"
-      );
-    }
-
     storage.clear();
 
     client.writeQuery({


### PR DESCRIPTION
It fixes external token refresh by making external logout call optional for internal methods, like sdk fetch.