### PR TITLE
Add missing token param to verifyToken

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -61,6 +61,7 @@ import {
   VerifyTokenResult,
   GetExternalAuthUrlOpts,
   GetExternalAccessTokenOpts,
+  VerifyTokenOpts,
 } from "./types";
 import {
   ChangePasswordOpts,
@@ -134,10 +135,10 @@ export interface AuthSDK {
   /**
    * Verify JWT token.
    *
-   * @param token - Token value.
+   * @param opts - Object with token value.
    * @returns User assigned to token and the information if the token is valid or not.
    */
-  verifyToken: () => Promise<VerifyTokenResult>;
+  verifyToken: (opts?: VerifyTokenOpts) => Promise<VerifyTokenResult>;
   /**
    * Executing externalAuthenticationUrl mutation will prepare special URL which will redirect user to requested
    * page after successfull authentication. After redirection state and code fields will be added to the URL.
@@ -300,8 +301,8 @@ export const auth = ({
     });
   };
 
-  const verifyToken: AuthSDK["verifyToken"] = async () => {
-    const token = storage.getAccessToken();
+  const verifyToken: AuthSDK["verifyToken"] = async opts => {
+    const token = opts?.token || storage.getAccessToken();
 
     if (!token) {
       throw Error("Token not present");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -41,6 +41,7 @@ import {
   RequestEmailChangeMutation,
   SetAccountDefaultAddressMutation,
   UpdateAccountAddressMutation,
+  MutationTokenVerifyArgs,
 } from "../apollo/types";
 import { AuthSDK } from "./auth";
 import { UserSDK } from "./user";
@@ -100,6 +101,7 @@ export type SetPasswordOpts = MutationSetPasswordArgs;
 export type GetExternalAuthUrlOpts = MutationExternalAuthenticationUrlArgs;
 export type GetExternalAccessTokenOpts = MutationExternalObtainAccessTokensArgs;
 export type LogoutOpts = Pick<MutationExternalLogoutArgs, "input">;
+export type VerifyTokenOpts = MutationTokenVerifyArgs;
 // User
 export type CreateAccountAddressOpts = MutationAccountAddressCreateArgs;
 export type RequestEmailChangeOpts = MutationRequestEmailChangeArgs;


### PR DESCRIPTION
SDK's auth method `verifyToken` is missing an optional argument to verify the token manually by user. SDK's auth method should reflect the current API state. Right now the user is not able to manually verify the auth token by using SDK.