### PR TITLE
fix: refresh proper token based on owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 .env
 .envrc
+*.tgz

--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
   "size-limit": [
     {
       "path": "dist/sdk.cjs.production.min.js",
-      "limit": "10 KB"
+      "limit": "11 KB"
     },
     {
       "path": "dist/sdk.esm.js",
-      "limit": "10 KB"
+      "limit": "11 KB"
     }
   ],
   "devDependencies": {

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -1,18 +1,19 @@
 import {
   ApolloClient,
-  createHttpLink,
+  FetchResult,
   InMemoryCache,
   NormalizedCacheObject,
   Reference,
-  FetchResult,
+  createHttpLink,
 } from "@apollo/client";
 import fetch from "cross-fetch";
 import jwtDecode from "jwt-decode";
 
-import { TypedTypePolicies } from "./apollo-helpers";
 import { JWTToken } from "../core";
 import { AuthSDK, auth } from "../core/auth";
 import { storage } from "../core/storage";
+import { isInternalToken } from "../helpers";
+import { TypedTypePolicies } from "./apollo-helpers";
 import { ExternalRefreshMutation, RefreshTokenMutation } from "./types";
 
 let client: ApolloClient<NormalizedCacheObject>;
@@ -57,7 +58,7 @@ export const createFetch = ({
   }
 
   let token = storage.getAccessToken();
-  const authPluginId = storage.getAuthPluginId();
+  // const authPluginId = storage.getAuthPluginId();
 
   try {
     if (
@@ -73,18 +74,19 @@ export const createFetch = ({
 
   if (autoTokenRefresh && token) {
     // auto refresh token before provided time skew (in seconds) until it expires
-    const expirationTime =
-      (jwtDecode<JWTToken>(token).exp - tokenRefreshTimeSkew) * 1000;
+    const decodedToken = jwtDecode<JWTToken>(token);
+    const expirationTime = (decodedToken.exp - tokenRefreshTimeSkew) * 1000;
+    const owner = decodedToken.owner;
 
     try {
       if (refreshPromise) {
         await refreshPromise;
       } else if (Date.now() >= expirationTime) {
-        // refreshToken automatically updates token in storage
-        refreshPromise = authPluginId
-          ? authClient.refreshExternalToken()
-          : authClient.refreshToken();
-        await refreshPromise;
+        if (isInternalToken(owner)) {
+          await authClient.refreshToken();
+        } else {
+          await authClient.refreshExternalToken();
+        }
       }
     } catch (e) {
     } finally {
@@ -111,15 +113,16 @@ export const createFetch = ({
       Record<string, unknown>,
       Record<string, unknown>
     > | null = null;
+    const owner = jwtDecode<JWTToken>(token).owner;
 
     if (isUnauthenticated) {
       try {
         if (refreshPromise) {
           refreshTokenResponse = await refreshPromise;
         } else {
-          refreshPromise = authPluginId
-            ? authClient.refreshExternalToken()
-            : authClient.refreshToken();
+          refreshPromise = isInternalToken(owner)
+            ? authClient.refreshToken()
+            : authClient.refreshExternalToken();
           refreshTokenResponse = await refreshPromise;
         }
 

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -58,7 +58,6 @@ export const createFetch = ({
   }
 
   let token = storage.getAccessToken();
-  // const authPluginId = storage.getAuthPluginId();
 
   try {
     if (

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,1 @@
+export const isInternalToken = (owner: string): boolean => owner === "saleor";

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -35,6 +35,7 @@ export const createTestToken = (
     {
       data: Math.random(), // to prevent generating the same tokens within the same second - some tests may try to create tokens quickly
       exp: Math.floor(Date.now() / 1000) + expirationPeriodInSeconds,
+      owner: "saleor",
     },
     testTokenSecret
   );


### PR DESCRIPTION
After this PR `owner` of the token will be responsible for determining if SDK should refresh the internal or external token.